### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,8 @@ android:
 script:
     # - ./gradlew connectedAndroidTest
     - ./gradlew testDebug jacocoTestReport coveralls
+
+cache:
+  directories:
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
